### PR TITLE
Add Icon style

### DIFF
--- a/src/OpenLayers/Style/Icon.js
+++ b/src/OpenLayers/Style/Icon.js
@@ -1,0 +1,18 @@
+//
+// The Openlayers Icon API mapping for purescript.
+//
+// This is just a very crude mapping and only helps out with what I need for the application
+// that I currently have on hand. It is no complete mapping.
+//
+//
+"use strict";
+
+// Get hold of the OpenLayer types and functions
+var ol  = require ('ol');
+var olst  = require ('ol/style');
+
+exports.createImpl = function (opt) {
+    return function() {
+        return new olst.Icon(opt);
+    }
+}

--- a/src/OpenLayers/Style/Icon.purs
+++ b/src/OpenLayers/Style/Icon.purs
@@ -1,0 +1,61 @@
+-- |
+-- | The OpenLayers Icon module, a purescript FFI mapping. 
+-- |
+-- | All functions and types of the OpenLayer API are currently not mapped.
+-- |
+-- | Functions, types or constants not part of the OpenLayers API or have
+-- | a different semantics are documented in this module, otherwise they
+-- | are documented in the OpenLayers API documentation.
+-- |
+-- | https://openlayers.org/en/latest/apidoc/
+module OpenLayers.Style.Icon (
+
+    Icon
+  , Options(..)
+  , create
+  , create'
+  ) where
+
+-- Data imports
+import Data.Function.Uncurried
+  ( Fn1
+  , runFn1)
+
+-- Standard import
+import Prim.Row (class Union)
+
+-- Effect imports
+import Effect (Effect)
+
+-- Own imports
+import OpenLayers.FFI as FFI
+import OpenLayers.Style.Fill as Fill
+import OpenLayers.Style.Stroke as Stroke
+
+--
+-- Foreign data types
+-- 
+foreign import data Icon :: Type
+
+--
+-- Function mapping
+--
+foreign import createImpl :: forall r . Fn1 (FFI.NullableOrUndefined (Record r)) (Effect Icon)
+
+-- |The options for the creation of the Icon. See the `options` parameter in `new Icon(options)` in the OpenLayers API documentation.
+type Options = (anchor :: Array Number
+  , size :: Array Int
+  , offset :: Array Int
+  , opacity :: Number 
+  , scale :: Number
+  , fill :: Fill.Fill
+  , stroke :: Stroke.Stroke
+  , src :: String)
+
+-- |Creates an `Icon`, see `new Icon(r)` in the OpenLayers API documentation.
+create :: forall l r . Union l r Options => Record l -> Effect Icon
+create r = runFn1 createImpl (FFI.notNullOrUndefined r)
+
+-- |Creates an `Icon` with defaults, see `new Icon()` in the OpenLayers API documentation.
+create' :: Effect Icon
+create' = runFn1 createImpl FFI.undefined

--- a/src/OpenLayers/Style/Icon.purs
+++ b/src/OpenLayers/Style/Icon.purs
@@ -31,14 +31,14 @@ import Effect (Effect)
 -- Own imports
 import OpenLayers.FFI as FFI
 import OpenLayers.Style.Fill as Fill
-import OpenLayers.Style.Image (RawImageStyle) as Image
+import OpenLayers.Style.Image (ImageStyle) as Image
 import OpenLayers.Style.Stroke as Stroke
 
 --
 -- Foreign data types
 -- 
 foreign import data RawIconStyle :: Type
-type Icon = Image.RawImageStyle RawIconStyle
+type Icon = Image.ImageStyle RawIconStyle
 
 --
 -- Function mapping

--- a/src/OpenLayers/Style/Icon.purs
+++ b/src/OpenLayers/Style/Icon.purs
@@ -11,6 +11,7 @@
 module OpenLayers.Style.Icon (
 
     Icon
+  , RawIconStyle
   , Options(..)
   , create
   , create'
@@ -30,12 +31,14 @@ import Effect (Effect)
 -- Own imports
 import OpenLayers.FFI as FFI
 import OpenLayers.Style.Fill as Fill
+import OpenLayers.Style.Image (ImageStyle) as Image
 import OpenLayers.Style.Stroke as Stroke
 
 --
 -- Foreign data types
 -- 
-foreign import data Icon :: Type
+foreign import data RawIconStyle :: Type
+type Icon = Image.ImageStyle RawIconStyle
 
 --
 -- Function mapping

--- a/src/OpenLayers/Style/Icon.purs
+++ b/src/OpenLayers/Style/Icon.purs
@@ -47,6 +47,8 @@ foreign import createImpl :: forall r . Fn1 (FFI.NullableOrUndefined (Record r))
 
 -- |The options for the creation of the Icon. See the `options` parameter in `new Icon(options)` in the OpenLayers API documentation.
 type Options = (anchor :: Array Number
+  , anchorXUnits :: String
+  , anchorYUnits :: String
   , size :: Array Int
   , offset :: Array Int
   , opacity :: Number 

--- a/src/OpenLayers/Style/Icon.purs
+++ b/src/OpenLayers/Style/Icon.purs
@@ -31,14 +31,14 @@ import Effect (Effect)
 -- Own imports
 import OpenLayers.FFI as FFI
 import OpenLayers.Style.Fill as Fill
-import OpenLayers.Style.Image (ImageStyle) as Image
+import OpenLayers.Style.Image (RawImageStyle) as Image
 import OpenLayers.Style.Stroke as Stroke
 
 --
 -- Foreign data types
 -- 
 foreign import data RawIconStyle :: Type
-type Icon = Image.ImageStyle RawIconStyle
+type Icon = Image.RawImageStyle RawIconStyle
 
 --
 -- Function mapping

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,13 +4,8 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Class.Console (log)
-import OpenLayers.Style.Icon as Icon
-import OpenLayers.Style.Style as Style
 
 main :: Effect Unit
 main = do
   log "🍝"
-  log "play with the Icon."
-  picon <- Icon.create'
-  style <- Style.create { image : picon }
-  pure unit
+  log "You should add some tests."

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,8 +4,13 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Class.Console (log)
+import OpenLayers.Style.Icon as Icon
+import OpenLayers.Style.Style as Style
 
 main :: Effect Unit
 main = do
   log "🍝"
-  log "You should add some tests."
+  log "play with the Icon."
+  picon <- Icon.create'
+  style <- Style.create { image : picon }
+  pure unit


### PR DESCRIPTION
Great library!  Would you be amenable to adding the Icon Style?  

Very sorry about the extremely uneven commit history.  The first two were fine, I then decided, mistakenly, to derive from ```RawImage``` rather than ```Image```.  I then compounded the problem by trying an awkward rebase to reverse the third commit, but in the end, after adding the X and Y units for anchor, I gave up and resynced with your master and re-edited to put back the ```Image``` inheritance.